### PR TITLE
Matthew Mierzwa - Branch 2 - Update events / Created CustomMapper

### DIFF
--- a/sql-access-layer/sql-access-layer/pom.xml
+++ b/sql-access-layer/sql-access-layer/pom.xml
@@ -53,12 +53,32 @@
 				<artifactId>mockito-junit-jupiter</artifactId>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.mapstruct</groupId>
+				<artifactId>mapstruct</artifactId>
+				<version>1.4.2.Final</version>
+			</dependency>
 		</dependencies>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>11</source>
+					<target>11</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.4.1.Final</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/sql-access-layer/sql-access-layer/src/main/java/com/cancerup/sqlaccesslayer/controller/EventController.java
+++ b/sql-access-layer/sql-access-layer/src/main/java/com/cancerup/sqlaccesslayer/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.cancerup.sqlaccesslayer.controller;
 import com.cancerup.sqlaccesslayer.EventRepository;
 import com.cancerup.sqlaccesslayer.models.*;
+import com.cancerup.sqlaccesslayer.util.CustomMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,8 @@ public class EventController {
 
     @Autowired
     private EventRepository eventRepository;
+    @Autowired
+    private CustomMapper mapper;
 
     @RequestMapping(value="/createevent", method= RequestMethod.POST)
     public ResponseEntity<Void> createEvent(@RequestBody Event event)  {
@@ -35,6 +38,17 @@ public class EventController {
     public ResponseEntity<Optional> requestEvents(@RequestParam long userId) {
         Optional<List<Event>> response = eventRepository.findAllByUserId(userId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @RequestMapping(value="/updateevent", method= RequestMethod.POST)
+    public ResponseEntity<Optional> updateEvent(@RequestBody Event event, @RequestParam long eventId)  {
+        Optional<Event> myEvent = eventRepository.findByEventId(eventId);
+        if(myEvent.isPresent()){
+            mapper.updateEventFromDto(event, myEvent.get());
+            eventRepository.save(myEvent.get());
+            return ResponseEntity.status(HttpStatus.CREATED).body(myEvent); 
+        }
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(null); // error 409
     }
 
     @RequestMapping(value="/deleteevents", method= RequestMethod.DELETE)

--- a/sql-access-layer/sql-access-layer/src/main/java/com/cancerup/sqlaccesslayer/models/Event.java
+++ b/sql-access-layer/sql-access-layer/src/main/java/com/cancerup/sqlaccesslayer/models/Event.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @Table(name = "events")
 public class Event {
     @Id
-    private long eventId;
+    private Long eventId;
     @NotNull
     private long userId;
     @NotNull
@@ -48,11 +48,11 @@ public class Event {
 
     public Event(){ }
 
-    public long getEventId() {
+    public Long getEventId() {
         return eventId;
     }
 
-    public void setEventId(long eventId) {
+    public void setEventId(Long eventId) {
         this.eventId = eventId;
     }
 

--- a/sql-access-layer/sql-access-layer/src/main/java/com/cancerup/sqlaccesslayer/util/CustomMapper.java
+++ b/sql-access-layer/sql-access-layer/src/main/java/com/cancerup/sqlaccesslayer/util/CustomMapper.java
@@ -1,0 +1,15 @@
+package com.cancerup.sqlaccesslayer.util;
+
+import com.cancerup.sqlaccesslayer.models.Event;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+//It would be interesting to see if we can just use one Mapper interface to update all of our datatypes!
+
+@Mapper(componentModel = "spring")
+public interface CustomMapper {
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEventFromDto(Event dto, @MappingTarget Event entity);
+}

--- a/sql-access-layer/sql-access-layer/src/test/java/com/cancerup/sqlaccesslayer/SqlAccessLayerTests.java
+++ b/sql-access-layer/sql-access-layer/src/test/java/com/cancerup/sqlaccesslayer/SqlAccessLayerTests.java
@@ -180,7 +180,7 @@ public class SqlAccessLayerTests {
 		String requestBody = new ObjectMapper().valueToTree(event2).toString();
 		this.mockMvc.perform(
 				post("/updateevent")
-						.param("eventId", Long.toString(15)) //event.getEventId()
+						.param("eventId", Long.toString(15)) // use a valid eventId from the DB, the mock tests above do not have correct id's to help update DB
 						.content(requestBody)
 						.contentType(MediaType.APPLICATION_JSON)
 						.accept(MediaType.APPLICATION_JSON)

--- a/sql-access-layer/sql-access-layer/src/test/java/com/cancerup/sqlaccesslayer/SqlAccessLayerTests.java
+++ b/sql-access-layer/sql-access-layer/src/test/java/com/cancerup/sqlaccesslayer/SqlAccessLayerTests.java
@@ -44,6 +44,8 @@ public class SqlAccessLayerTests {
 	User user = new User("test@gmail.com", "password", "Test", "USER");
 	//This is our mock event we are going to use
 	Event event = new Event(2, "Test", LocalDate.now().toString());
+	//This is our second mock event we are going to use to test updating back and forth between events!
+	Event event2 = new Event(3, "Test2", LocalDate.now().toString());
 	//This is our global contact we are create/add. The user 44 is a test user (Mickey Mouse)
 	Contact contact = new Contact(new User(44), "Donald", "Duck");
 
@@ -172,5 +174,18 @@ public class SqlAccessLayerTests {
 				.andDo(print()).andExpect(status().isOk());
 	}
 
+	@Test
+	@Order(11)
+	public void testUpdateEvents() throws Exception {
+		String requestBody = new ObjectMapper().valueToTree(event2).toString();
+		this.mockMvc.perform(
+				post("/updateevent")
+						.param("eventId", Long.toString(15)) //event.getEventId()
+						.content(requestBody)
+						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON)
+		)
+				.andDo(print()).andExpect(status().isCreated());
+	}
 }
 


### PR DESCRIPTION
With this update we now have an interface in the util folder called CustomMapper
CustomMapper takes two objects of the same type and copies over all the information from the dto to the entitiy. The only thing unchanged is the primary key of the Mapping target.

To use the CustomMapper, add another updateDataTypeFromDto(DataType dto, @MappingTarget DataType entity); method just replace DataType with whichever type you need.

In regards to testing, I originally tried to do event.getEventId() , but this didn't work because the object was not already in the database. So, to test your updates make sure you're using an eventId that is already in the DB.

Let me know if anything needs to be clarified!